### PR TITLE
Fix integer bug

### DIFF
--- a/mathfly/ccr/core.py
+++ b/mathfly/ccr/core.py
@@ -6,6 +6,7 @@ Created on Sep 4, 2018
 from dragonfly import Function, Choice, Key, Text, Mouse, IntegerRef, Dictation, Repeat
 
 from mathfly.lib import control, utilities, navigation
+from mathfly.lib.integers import IntegerRefMF
 from mathfly.lib.merge.mergerule import MergeRule
 
 SETTINGS = utilities.load_toml_relative("config/settings.toml")
@@ -72,7 +73,7 @@ class core(MergeRule):
         Dictation("text"),
     	IntegerRef("n", 1, 10),
         IntegerRef("n50", 1, 50),
-        IntegerRef("numbers", 0,     CORE["numbers_max"]),
+        IntegerRefMF("numbers", 0,   CORE["numbers_max"]),
         Choice("big",               {CORE["capitals_prefix"]: True}),
     	Choice("letter",             CORE[_LETTERS]),
     	Choice("punctuation",        CORE["punctuation"]),

--- a/mathfly/config/core.toml
+++ b/mathfly/config/core.toml
@@ -1,6 +1,6 @@
 # Once you have finished making changes, use the "rebuild mathfly"
 # command to enact them.
-"numbers_max"      = 500
+"numbers_max"      = 1000
 "pronunciation"    = "(Core | math fly)"
 "capitals_prefix"  = "big"
 # Square brackets mean that a word is optional:

--- a/mathfly/lib/integers.py
+++ b/mathfly/lib/integers.py
@@ -1,0 +1,94 @@
+from dragonfly.language.base.integer_internal import MapIntBuilder, MagnitudeIntBuilder, IntegerContentBase, CollectionIntBuilder
+from dragonfly.language.base.integer import Integer
+from dragonfly.grammar.elements_basic import RuleWrap
+
+
+
+
+
+int_0           = MapIntBuilder({
+                                 "zero":       0,
+                               })
+int_1_9         = MapIntBuilder({
+                                 "one":        1,
+                                 "two":        2,
+                                 "three":      3,
+                                 "four":       4,
+                                 "five":       5,
+                                 "six":        6,
+                                 "seven":      7,
+                                 "eight":      8,
+                                 "nine":       9,
+                               })
+int_10_19       = MapIntBuilder({
+                                 "ten":       10,
+                                 "eleven":    11,
+                                 "twelve":    12,
+                                 "thirteen":  13,
+                                 "fourteen":  14,
+                                 "fifteen":   15,
+                                 "sixteen":   16,
+                                 "seventeen": 17,
+                                 "eighteen":  18,
+                                 "nineteen":  19,
+                               })
+int_20_90_10    = MapIntBuilder({
+                                 "twenty":     2,
+                                 "thirty":     3,
+                                 "forty":      4,
+                                 "fifty":      5,
+                                 "sixty":      6,
+                                 "seventy":    7,
+                                 "eighty":     8,
+                                 "ninety":     9,
+                               })
+int_20_99       = MagnitudeIntBuilder(
+                   factor      = 10,
+                   spec        = "<multiplier> [<remainder>]",
+                   multipliers = [int_20_90_10],
+                   remainders  = [int_1_9],
+                  )
+int_and_1_99    = CollectionIntBuilder(
+                   spec        = "[and] <element>",
+                   set         = [int_1_9, int_10_19, int_20_99],
+                  )
+int_100s        = MagnitudeIntBuilder(
+                   factor      = 100,
+                   spec        = "<multiplier> hundred [<remainder>]",
+                   multipliers = [int_1_9],
+                   remainders  = [int_and_1_99],
+                  )
+int_100big      = MagnitudeIntBuilder(
+                   factor      = 100,
+                   spec        = "<multiplier> hundred [<remainder>]",
+                   multipliers = [int_10_19, int_20_99],
+                   remainders  = [int_and_1_99]
+                  )
+int_1000s       = MagnitudeIntBuilder(
+                   factor      = 1000,
+                   spec        = "<multiplier> thousand [<remainder>]",
+                   multipliers = [int_1_9, int_10_19, int_20_99, int_100s],
+                   remainders  = [int_and_1_99, int_100s]
+                  )
+int_1000000s    = MagnitudeIntBuilder(
+                   factor      = 1000000,
+                   spec        = "<multiplier> million [<remainder>]",
+                   multipliers = [int_1_9, int_10_19, int_20_99, int_100s, int_1000s],
+                   remainders  = [int_and_1_99, int_100s, int_1000s],
+                  )
+
+
+#---------------------------------------------------------------------------
+
+class IntegerContent(IntegerContentBase):
+    builders = [int_0, int_1_9, int_10_19, int_20_99,
+                int_100s, int_100big, int_1000s, int_1000000s]
+
+
+#---------------------------------------------------------------------------
+# Integer reference class.
+
+class IntegerRefMF(RuleWrap):
+    def __init__(self, name, min, max, default=None):
+        element = Integer(None, min, max, content=IntegerContent)
+        RuleWrap.__init__(self, name, element, default=default)


### PR DESCRIPTION
The regular dragonfly IntegerRef class allows for example "162" to be dictated as "hundred sixty two", dropping the "one". This provides some convenience but when you allow multiple numbers side-by-side in a repeat rule, as mathfly does, it causes problems. Since Dragon cannot distinguish between "four hundred thirty three" and "four, hundred thirty three", it produces "4133" instead of "433" as intended.

I've re-implemented the class so that it now requires "133" to be dictated as "one hundred thirty three", solving the problem. It should now be possible to dictate numbers any way you want:

* `four six two`
* `four sixty two`
* `four hundred sixty two`
* `forty six two`