### PR TITLE
add nested command for subscript and superscript in Lyx

### DIFF
--- a/mathfly/ccr/LyX.py
+++ b/mathfly/ccr/LyX.py
@@ -25,6 +25,10 @@ def matrix(rows, cols):
 
 class lyx_nested(NestedRule):
     mapping = {
+        "[<before>] subby <sequence1> [<sequence2>]":
+            [Text("_"), Key("right")],
+        "[<before>] to the <sequence1> [<sequence2>]":
+            [Text("^"), Key("right")],
         "[<before>] integral from <sequence1> to <sequence2>":
             [Text("\\int _"), Key("right, caret"), Key("right")],
 


### PR DESCRIPTION
Personally I kinda like having 'sub' be the spec for nested subscript (i.e. pressing underscore then executing the command then pressing right). The reason being that it is common to 2things in math like "x sub one". But you already have 'sub' for regular underscore, so I made it 'subby'. I use 'score' for underscore.

I think it's totally awesome that you have added this nested functionality– a real game changer for math by voice. It might be good to make it so you don't have to require "sequence1" and "sequence2". In this case, I have had to add "sequence2" into the command definition (since I believe it is required) even though "sequence2" isn't doing anything. Hopefully I will get a chance look at the underlying code in CCR_merger more closely soon.