### PR TITLE
Add imports.py

### DIFF
--- a/mathfly/apps/app_template.py
+++ b/mathfly/apps/app_template.py
@@ -1,8 +1,4 @@
-from dragonfly import (Grammar, Pause, Choice, Function, IntegerRef, Mimic, Playback)
-
-from mathfly.lib.actions import Text, Key, Mouse, AppContext
-from mathfly.lib.merge.mergerule import MergeRule
-from mathfly.lib import control
+from mathfly.imports import *
 
 class RuleNameRule(MergeRule):
 	pronunciation = "AppName"

--- a/mathfly/apps/sublime.py
+++ b/mathfly/apps/sublime.py
@@ -1,12 +1,8 @@
-from dragonfly import Grammar, Dictation, Choice, Repeat, IntegerRef
-
-from mathfly.lib.actions import Text, Key, Mouse, AppContext
-from mathfly.lib import control
-from mathfly.lib.merge.mergerule import MergeRule
-
+from mathfly.imports import *
 
 class SublimeRule(MergeRule):
     pronunciation = "sublime"
+    mcontext = AppContext(executable="sublime_text", title="Sublime Text")
 
     mapping = {
         "new (file | pane)": Key("c-n"),
@@ -131,8 +127,4 @@ class SublimeRule(MergeRule):
 
 #---------------------------------------------------------------------------
 
-context = AppContext(executable="sublime_text", title="Sublime Text")
-grammar = Grammar("Sublime", context=context)
-rule = SublimeRule(name="sublime")
-grammar.add_rule(rule)
-grammar.load()
+control.nexus().merger.add_non_ccr_app_rule(SublimeRule())

--- a/mathfly/apps/sumatrapdf.py
+++ b/mathfly/apps/sumatrapdf.py
@@ -1,8 +1,4 @@
-from dragonfly import (Grammar, Pause, Choice, Function, IntegerRef, Mimic, Playback)
-
-from mathfly.lib.actions import Text, Key, Mouse, AppContext
-from mathfly.lib.merge.mergerule import MergeRule
-from mathfly.lib import control
+from mathfly.imports import *
 
 class SumatraPDFRule(MergeRule):
 	pronunciation = "SumatraPDF"

--- a/mathfly/apps/wordpad.py
+++ b/mathfly/apps/wordpad.py
@@ -1,8 +1,4 @@
-from dragonfly import (Grammar, Pause, Choice, Function, IntegerRef, Mimic, Playback)
-
-from mathfly.lib.actions import Text, Key, Mouse, AppContext
-from mathfly.lib.merge.mergerule import MergeRule
-from mathfly.lib import control
+from mathfly.imports import *
 
 class WordPadRule(MergeRule):
 	pronunciation = "WordPad"

--- a/mathfly/ccr/LyX.py
+++ b/mathfly/ccr/LyX.py
@@ -3,13 +3,7 @@ Created Jan 2019
 
 @author: Mike Roberts, Alex Boche
 '''
-from dragonfly import Function, Choice, IntegerRef
-from dragonfly import Grammar, Repeat, CompoundRule
-
-from mathfly.lib.actions import Text, Key, Mouse, AppContext
-from mathfly.lib import control, utilities, execution
-from mathfly.lib.merge.mergerule import MergeRule
-from mathfly.lib.merge.nestedrule import NestedRule
+from mathfly.imports import *
 
 BINDINGS = utilities.load_toml_relative("config/lyx.toml")
 CORE     = utilities.load_toml_relative("config/core.toml")

--- a/mathfly/ccr/ScientificNotebook55.py
+++ b/mathfly/ccr/ScientificNotebook55.py
@@ -3,12 +3,7 @@ Created on Sep 4, 2018
 
 @author: Mike Roberts
 '''
-from dragonfly import Function, Choice, IntegerRef, Dictation, Repeat
-
-from mathfly.lib.actions import Text, Key, Mouse, AppContext
-from mathfly.lib import control, utilities, execution
-from mathfly.lib.merge.mergerule import MergeRule
-from mathfly.lib.merge.nestedrule import NestedRule
+from mathfly.imports import *
 
 BINDINGS = utilities.load_toml_relative("config/ScientificNotebook55.toml")
 CORE = utilities.load_toml_relative("config/core.toml")

--- a/mathfly/ccr/alias.py
+++ b/mathfly/ccr/alias.py
@@ -1,7 +1,4 @@
-from dragonfly import Dictation, Choice, Text, Function, IntegerRef
-
-from mathfly.lib import utilities, control
-from mathfly.lib.merge.selfmodrule import SelfModifyingRule
+from mathfly.imports import *
 
 MF_NEXUS = control.nexus()
 

--- a/mathfly/ccr/core.py
+++ b/mathfly/ccr/core.py
@@ -3,12 +3,7 @@ Created on Sep 4, 2018
 
 @author: Mike Roberts
 '''
-from dragonfly import Function, Choice, IntegerRef, Dictation, Repeat
-
-from mathfly.lib.actions import Text, Key, Mouse
-from mathfly.lib import control, utilities, navigation
-from mathfly.lib.integers import IntegerRefMF
-from mathfly.lib.merge.mergerule import MergeRule
+from mathfly.imports import *
 
 SETTINGS = utilities.load_toml_relative("config/settings.toml")
 CORE = utilities.load_toml_relative("config/core.toml")

--- a/mathfly/ccr/latex.py
+++ b/mathfly/ccr/latex.py
@@ -1,14 +1,8 @@
 '''
 Created on Sep 4, 2018
-
 @author: Mike Roberts
 '''
-from dragonfly import Function, Choice, Repeat, Clipboard
-
-from mathfly.lib.actions import Text, Key, Mouse, AppContext
-from mathfly.lib import control, utilities, execution
-from mathfly.lib.merge.mergerule import MergeRule
-from mathfly.lib.latex import tex_funcs
+from mathfly.imports import *
 
 BINDINGS = utilities.load_toml_relative("config/latex.toml")
 CORE = utilities.load_toml_relative("config/core.toml")

--- a/mathfly/ccr/latex_maths.py
+++ b/mathfly/ccr/latex_maths.py
@@ -3,10 +3,7 @@ Created on Sep 4, 2018
 
 @author: Mike Roberts
 '''
-from dragonfly import Function, Choice, Key, Text, IntegerRef
-
-from mathfly.lib import control, execution, utilities
-from mathfly.lib.merge.mergerule import MergeRule
+from mathfly.imports import *
 
 BINDINGS = utilities.load_toml_relative("config/latex.toml")
 CORE = utilities.load_toml_relative("config/core.toml")

--- a/mathfly/imports.py
+++ b/mathfly/imports.py
@@ -1,0 +1,12 @@
+from dragonfly import Dictation, MappingRule, Choice, Function, ContextAction, Repetition, Compound
+from dragonfly import Repeat, Playback, Mimic, Window, Clipboard
+
+from mathfly.lib.actions import Text, Key, Mouse, AppContext
+from mathfly.lib.integers import IntegerRefMF
+
+from mathfly.lib import control, utilities, execution, navigation
+from mathfly.lib.latex import tex_funcs
+
+from mathfly.lib.merge.mergerule import MergeRule
+from mathfly.lib.merge.nestedrule import NestedRule
+from mathfly.lib.merge.selfmodrule import SelfModifyingRule

--- a/mathfly/imports.py
+++ b/mathfly/imports.py
@@ -1,5 +1,9 @@
+'''
+from mathfly.imports import *
+'''
+
 from dragonfly import Dictation, MappingRule, Choice, Function, ContextAction, Repetition, Compound
-from dragonfly import Repeat, Playback, Mimic, Window, Clipboard
+from dragonfly import Repeat, Playback, Mimic, Window, Clipboard, IntegerRef, ShortIntegerRef
 
 from mathfly.lib.actions import Text, Key, Mouse, AppContext
 from mathfly.lib.integers import IntegerRefMF
@@ -10,3 +14,6 @@ from mathfly.lib.latex import tex_funcs
 from mathfly.lib.merge.mergerule import MergeRule
 from mathfly.lib.merge.nestedrule import NestedRule
 from mathfly.lib.merge.selfmodrule import SelfModifyingRule
+
+import re, os, datetime, sys
+from subprocess import Popen


### PR DESCRIPTION
Allows the standard import statements at the top of grammars to be replaced with just one line:
```
from mathfly.imports import *
```